### PR TITLE
Manual 'repolint' from TODO hackathon - license and contribution info improvements

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,21 @@
+# Contributing to ClearlyDefined
+
+The ClearlyDefined project welcomes your suggestions and contributions! Before opening your first issue or pull request, please review our
+[Code of Conduct](CODE_OF_CONDUCT.md) to understand how our community interacts in an inclusive and respectful manner.
+
+## Contribution Licensing - Code
+
+Most of our code is distributed under the terms of the [MIT license](LICENSE-MIT), and when you contribute code that you wrote to our repositories, 
+you agree that you are contributing under those same terms. In addition, by submitting your contributions you are indicating that
+you have the right to submit those contributions under those terms.
+
+## Contribution Licensing - Documentation
+
+Most of our documentation is distributed under the terms of the [Creative Commons CC0 1.0 Universal Public Domain Dedication](LICENSE), and when
+you contribute documentation that you wrote to our repositories, you agree that you are contributing under those same terms. In addition, by
+submitting your contributions you are indicating that you have the right to submit those contributions under those terms.
+
+## Other Contribution Information
+
+If you wish to contribute code or documentation authored by others, or using the terms of any other license, please indicate that clearly in your
+pull request so that the project team can discuss the situation with you.

--- a/LICENSE
+++ b/LICENSE
@@ -1,40 +1,132 @@
 Creative Commons CC0 1.0 Universal
 
-CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES NOT PROVIDE LEGAL SERVICES. DISTRIBUTION OF THIS DOCUMENT DOES NOT CREATE AN ATTORNEY-CLIENT RELATIONSHIP. CREATIVE COMMONS PROVIDES THIS INFORMATION ON AN "AS-IS" BASIS. CREATIVE COMMONS MAKES NO WARRANTIES REGARDING THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS PROVIDED HEREUNDER, AND DISCLAIMS LIABILITY FOR DAMAGES RESULTING FROM THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS PROVIDED HEREUNDER.
-Statement of Purpose
+CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES NOT PROVIDE
+LEGAL SERVICES. DISTRIBUTION OF THIS DOCUMENT DOES NOT CREATE AN
+ATTORNEY-CLIENT RELATIONSHIP. CREATIVE COMMONS PROVIDES THIS
+INFORMATION ON AN "AS-IS" BASIS. CREATIVE COMMONS MAKES NO WARRANTIES
+REGARDING THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS
+PROVIDED HEREUNDER, AND DISCLAIMS LIABILITY FOR DAMAGES RESULTING FROM
+THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS PROVIDED
+HEREUNDER.  Statement of Purpose
 
-The laws of most jurisdictions throughout the world automatically confer exclusive Copyright and Related Rights (defined below) upon the creator and subsequent owner(s) (each and all, an "owner") of an original work of authorship and/or a database (each, a "Work").
+The laws of most jurisdictions throughout the world automatically
+confer exclusive Copyright and Related Rights (defined below) upon the
+creator and subsequent owner(s) (each and all, an "owner") of an
+original work of authorship and/or a database (each, a "Work").
 
-Certain owners wish to permanently relinquish those rights to a Work for the purpose of contributing to a commons of creative, cultural and scientific works ("Commons") that the public can reliably and without fear of later claims of infringement build upon, modify, incorporate in other works, reuse and redistribute as freely as possible in any form whatsoever and for any purposes, including without limitation commercial purposes. These owners may contribute to the Commons to promote the ideal of a free culture and the further production of creative, cultural and scientific works, or to gain reputation or greater distribution for their Work in part through the use and efforts of others.
+Certain owners wish to permanently relinquish those rights to a Work
+for the purpose of contributing to a commons of creative, cultural and
+scientific works ("Commons") that the public can reliably and without
+fear of later claims of infringement build upon, modify, incorporate
+in other works, reuse and redistribute as freely as possible in any
+form whatsoever and for any purposes, including without limitation
+commercial purposes. These owners may contribute to the Commons to
+promote the ideal of a free culture and the further production of
+creative, cultural and scientific works, or to gain reputation or
+greater distribution for their Work in part through the use and
+efforts of others.
 
-For these and/or other purposes and motivations, and without any expectation of additional consideration or compensation, the person associating CC0 with a Work (the "Affirmer"), to the extent that he or she is an owner of Copyright and Related Rights in the Work, voluntarily elects to apply CC0 to the Work and publicly distribute the Work under its terms, with knowledge of his or her Copyright and Related Rights in the Work and the meaning and intended legal effect of CC0 on those rights.
+For these and/or other purposes and motivations, and without any
+expectation of additional consideration or compensation, the person
+associating CC0 with a Work (the "Affirmer"), to the extent that he or
+she is an owner of Copyright and Related Rights in the Work,
+voluntarily elects to apply CC0 to the Work and publicly distribute
+the Work under its terms, with knowledge of his or her Copyright and
+Related Rights in the Work and the meaning and intended legal effect
+of CC0 on those rights.
 
-1. Copyright and Related Rights. A Work made available under CC0 may be protected by copyright and related or neighboring rights ("Copyright and Related Rights"). Copyright and Related Rights include, but are not limited to, the following:
+1. Copyright and Related Rights. A Work made available under CC0 may
+be protected by copyright and related or neighboring rights
+("Copyright and Related Rights"). Copyright and Related Rights
+include, but are not limited to, the following:
 
-i. the right to reproduce, adapt, distribute, perform, display, communicate, and translate a Work;
+i. the right to reproduce, adapt, distribute, perform, display,
+communicate, and translate a Work;
 
-ii. moral rights retained by the original author(s) and/or performer(s);
+ii. moral rights retained by the original author(s) and/or
+performer(s);
 
-iii. publicity and privacy rights pertaining to a person's image or likeness depicted in a Work;
+iii. publicity and privacy rights pertaining to a person's image or
+likeness depicted in a Work;
 
-iv. rights protecting against unfair competition in regards to a Work, subject to the limitations in paragraph 4(a), below;
+iv. rights protecting against unfair competition in regards to a Work,
+subject to the limitations in paragraph 4(a), below;
 
-v. rights protecting the extraction, dissemination, use and reuse of data in a Work;
+v. rights protecting the extraction, dissemination, use and reuse of
+data in a Work;
 
-vi. database rights (such as those arising under Directive 96/9/EC of the European Parliament and of the Council of 11 March 1996 on the legal protection of databases, and under any national implementation thereof, including any amended or successor version of such directive); and
+vi. database rights (such as those arising under Directive 96/9/EC of
+the European Parliament and of the Council of 11 March 1996 on the
+legal protection of databases, and under any national implementation
+thereof, including any amended or successor version of such
+directive); and
 
-vii. other similar, equivalent or corresponding rights throughout the world based on applicable law or treaty, and any national implementations thereof.
+vii. other similar, equivalent or corresponding rights throughout the
+world based on applicable law or treaty, and any national
+implementations thereof.
 
-2. Waiver. To the greatest extent permitted by, but not in contravention of, applicable law, Affirmer hereby overtly, fully, permanently, irrevocably and unconditionally waives, abandons, and surrenders all of Affirmer's Copyright and Related Rights and associated claims and causes of action, whether now known or unknown (including existing as well as future claims and causes of action), in the Work (i) in all territories worldwide, (ii) for the maximum duration provided by applicable law or treaty (including future time extensions), (iii) in any current or future medium and for any number of copies, and (iv) for any purpose whatsoever, including without limitation commercial, advertising or promotional purposes (the "Waiver"). Affirmer makes the Waiver for the benefit of each member of the public at large and to the detriment of Affirmer's heirs and successors, fully intending that such Waiver shall not be subject to revocation, rescission, cancellation, termination, or any other legal or equitable action to disrupt the quiet enjoyment of the Work by the public as contemplated by Affirmer's express Statement of Purpose.
+2. Waiver. To the greatest extent permitted by, but not in
+contravention of, applicable law, Affirmer hereby overtly, fully,
+permanently, irrevocably and unconditionally waives, abandons, and
+surrenders all of Affirmer's Copyright and Related Rights and
+associated claims and causes of action, whether now known or unknown
+(including existing as well as future claims and causes of action), in
+the Work (i) in all territories worldwide, (ii) for the maximum
+duration provided by applicable law or treaty (including future time
+extensions), (iii) in any current or future medium and for any number
+of copies, and (iv) for any purpose whatsoever, including without
+limitation commercial, advertising or promotional purposes (the
+"Waiver"). Affirmer makes the Waiver for the benefit of each member of
+the public at large and to the detriment of Affirmer's heirs and
+successors, fully intending that such Waiver shall not be subject to
+revocation, rescission, cancellation, termination, or any other legal
+or equitable action to disrupt the quiet enjoyment of the Work by the
+public as contemplated by Affirmer's express Statement of Purpose.
 
-3. Public License Fallback. Should any part of the Waiver for any reason be judged legally invalid or ineffective under applicable law, then the Waiver shall be preserved to the maximum extent permitted taking into account Affirmer's express Statement of Purpose. In addition, to the extent the Waiver is so judged Affirmer hereby grants to each affected person a royalty-free, non transferable, non sublicensable, non exclusive, irrevocable and unconditional license to exercise Affirmer's Copyright and Related Rights in the Work (i) in all territories worldwide, (ii) for the maximum duration provided by applicable law or treaty (including future time extensions), (iii) in any current or future medium and for any number of copies, and (iv) for any purpose whatsoever, including without limitation commercial, advertising or promotional purposes (the "License"). The License shall be deemed effective as of the date CC0 was applied by Affirmer to the Work. Should any part of the License for any reason be judged legally invalid or ineffective under applicable law, such partial invalidity or ineffectiveness shall not invalidate the remainder of the License, and in such case Affirmer hereby affirms that he or she will not (i) exercise any of his or her remaining Copyright and Related Rights in the Work or (ii) assert any associated claims and causes of action with respect to the Work, in either case contrary to Affirmer's express Statement of Purpose.
+3. Public License Fallback. Should any part of the Waiver for any
+reason be judged legally invalid or ineffective under applicable law,
+then the Waiver shall be preserved to the maximum extent permitted
+taking into account Affirmer's express Statement of Purpose. In
+addition, to the extent the Waiver is so judged Affirmer hereby grants
+to each affected person a royalty-free, non transferable, non
+sublicensable, non exclusive, irrevocable and unconditional license to
+exercise Affirmer's Copyright and Related Rights in the Work (i) in
+all territories worldwide, (ii) for the maximum duration provided by
+applicable law or treaty (including future time extensions), (iii) in
+any current or future medium and for any number of copies, and (iv)
+for any purpose whatsoever, including without limitation commercial,
+advertising or promotional purposes (the "License"). The License shall
+be deemed effective as of the date CC0 was applied by Affirmer to the
+Work. Should any part of the License for any reason be judged legally
+invalid or ineffective under applicable law, such partial invalidity
+or ineffectiveness shall not invalidate the remainder of the License,
+and in such case Affirmer hereby affirms that he or she will not (i)
+exercise any of his or her remaining Copyright and Related Rights in
+the Work or (ii) assert any associated claims and causes of action
+with respect to the Work, in either case contrary to Affirmer's
+express Statement of Purpose.
 
 4. Limitations and Disclaimers.
 
-a. No trademark or patent rights held by Affirmer are waived, abandoned, surrendered, licensed or otherwise affected by this document.
+a. No trademark or patent rights held by Affirmer are waived,
+abandoned, surrendered, licensed or otherwise affected by this
+document.
 
-b. Affirmer offers the Work as-is and makes no representations or warranties of any kind concerning the Work, express, implied, statutory or otherwise, including without limitation warranties of title, merchantability, fitness for a particular purpose, non infringement, or the absence of latent or other defects, accuracy, or the present or absence of errors, whether or not discoverable, all to the greatest extent permissible under applicable law.
+b. Affirmer offers the Work as-is and makes no representations or
+warranties of any kind concerning the Work, express, implied,
+statutory or otherwise, including without limitation warranties of
+title, merchantability, fitness for a particular purpose, non
+infringement, or the absence of latent or other defects, accuracy, or
+the present or absence of errors, whether or not discoverable, all to
+the greatest extent permissible under applicable law.
 
-c. Affirmer disclaims responsibility for clearing rights of other persons that may apply to the Work or any use thereof, including without limitation any person's Copyright and Related Rights in the Work. Further, Affirmer disclaims responsibility for obtaining any necessary consents, permissions or other rights required for any use of the Work.
+c. Affirmer disclaims responsibility for clearing rights of other
+persons that may apply to the Work or any use thereof, including
+without limitation any person's Copyright and Related Rights in the
+Work. Further, Affirmer disclaims responsibility for obtaining any
+necessary consents, permissions or other rights required for any use
+of the Work.
 
-d. Affirmer understands and acknowledges that Creative Commons is not a party to this document and has no duty or obligation with respect to this CC0 or use of the Work.
+d. Affirmer understands and acknowledges that Creative Commons is not
+a party to this document and has no duty or obligation with respect to
+this CC0 or use of the Work.

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright 2018 Microsoft Corporation and others.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -3,13 +3,11 @@
 ## Mission
 Help FOSS projects be more successful through clearly defined project data.
 
-For more details on the project, check out the [wiki](https://github.com/clearlydefined/clearlydefined/wiki)
+For more details on the project, check out the [wiki](../../wiki).
 
 # Contributing
 
-This project welcomes contributions and suggestions. Our contribution policy is [as follows](https://github.com/clearlydefined/clearlydefined/blob/master/contributing.md):
-
-Whenever you make a contribution to a Clearly Defined repository containing notice of a license, you license your contribution under the same terms, and you agree that you have the right to license your contribution under those terms.
+This project welcomes contributions and suggestions, and we've documented the details of contribution policy [here](CONTRIBUTING.md).
 
 The [Code of Conduct](CODE_OF_CONDUCT.md) for this project is details how the community interacts in 
 an inclusive and respectful manner. Please keep it in mind as you engage here.

--- a/contributing.md
+++ b/contributing.md
@@ -1,1 +1,0 @@
- Whenever you make a contribution to a Clearly Defined repository containing notice of a license, you license your contribution under the same terms, and you agree that you have the right to license your contribution under those terms.


### PR DESCRIPTION
Improve contribution policy language and make it easier to find.

Add copy of MIT license, and remove 'All rights reserved. to match OSI-approved license text.

Clarify that two licenses are used and indicate which types of content
they are used for.