### PR TITLE
Updating troubleshooting #1

### DIFF
--- a/docs/curation-guidelines.md
+++ b/docs/curation-guidelines.md
@@ -81,7 +81,7 @@ If the canonical locations do not match (e.g., the license file states Apache-2.
 ## Troubleshooting
 We always prefer a reference to a version control system, but if you’re unable to find that, other public references are okay.
 1. Target component metadata gives a URL that points to a volatile location (e.g. a webpage or the master branch of a git repository).
-    * Apply license found at the volatile location at the time checked.
+    * Look for evidence of the license at the time the target component was published.
 1. Target component metadata points to a license file URL in source repository, but the link is broken.
     * Ignore the link specifics and look for license information in other canonical locations in that source repository.
 1. Target component has no project/source location and does not have any license information. There exists a related version (newer or older) that does have license information.


### PR DESCRIPTION
Following convention that the license at the time the code was made available, is the license that applies to that code at that point in time, even if the license is changed later.