### PR TITLE
Add API rate limits

### DIFF
--- a/docs/using-data.md
+++ b/docs/using-data.md
@@ -6,18 +6,20 @@ All of the ClearlyDefined data is available for everyone to see and use. You can
 
 ClearlyDefined enforces specific rate limits on REST API calls to ensure stability and integrity of the platform. 
 
-You can check the _x-ratelimit-limit_ and _x-ratelimit-remaining_ response headers to track your usage.
+You can check the _x-ratelimit-limit_ and _x-ratelimit-remaining_ response headers to track your usage and reset window.
+
+If the rate limit is reached, an _HTTP 429_ response code will be returned. The rate limit is based on the window below.
 
 ### Production Instance Rate Limits
 
 Host: [api.clearlydefined.io](https://api.clearlydefined.io/)
 \([Docs](https://api.clearlydefined.io/api-docs/)\)
 
-| Endpoint      | Method  | Limit    |
-|---------------|---------|----------|
-| /definitions  | POST    | 250 /min |
-| /curations    | POST    | 250 /min |
-| /notices      | POST    | 250 /min |
+| Endpoint      | Method  | Limit    | Window |
+|---------------|---------|----------|--------|
+| /definitions  | POST    | 250 /min | 1 min  |
+| /curations    | POST    | 250 /min | 1 min  |
+| /notices      | POST    | 250 /min | 1 min  |
 
 All other endpoints are max 2K requests per minute. 
 
@@ -26,11 +28,11 @@ All other endpoints are max 2K requests per minute.
 Host: [dev-api.clearlydefined.io](https://dev-api.clearlydefined.io/)
 \([Docs](https://dev-api.clearlydefined.io/api-docs/)\)
 
-| Endpoint      | Method  | Limit    |
-|---------------|---------|----------|
-| /definitions  | POST    | 250 /min |
-| /curations    | POST    | 250 /min |
-| /notices      | POST    | 250 /min |
+| Endpoint      | Method  | Limit    | Window |
+|---------------|---------|----------|--------|
+| /definitions  | POST    | 250 /min | 5 min  |
+| /curations    | POST    | 250 /min | 5 min  |
+| /notices      | POST    | 250 /min | 5 min  |
 
 All other endpoints are max 500 requests per every 5 minutes.
 

--- a/docs/using-data.md
+++ b/docs/using-data.md
@@ -2,11 +2,29 @@
 
 All of the ClearlyDefined data is available for everyone to see and use. You can browse and inspect in a [convenient web ui](#website) or hook up a client to the [REST API](https://api.clearlydefined.io/api-docs/) and integrate it into your systems.
 
-## API Usage Considerations
+## REST API Usage Considerations
 
-Current rate limits are as follows:
+ClearlyDefined enforces specific rate limits on REST API calls to ensure stability and integrity of the platform. 
 
-### Endpoint-Specific Restrictions
+You can check the _x-ratelimit-limit_ and _x-ratelimit-remaining_ response headers to track your usage.
+
+### Production Instance Rate Limits
+
+Host: [api.clearlydefined.io](https://api.clearlydefined.io/)
+\([Docs](https://api.clearlydefined.io/api-docs/)\)
+
+| Endpoint      | Method  | Limit    |
+|---------------|---------|----------|
+| /definitions  | POST    | 60 /min  |
+| /curations    | POST    | 60 /min  |
+| /notices      | POST    | 60 /min  |
+
+All other endpoints are max 2K requests per minute. 
+
+### Development Instance Rate Limits
+
+Host: [dev-api.clearlydefined.io](https://dev-api.clearlydefined.io/)
+\([Docs](https://dev-api.clearlydefined.io/api-docs/)\)
 
 | Endpoint      | Method  | Limit    |
 |---------------|---------|----------|
@@ -14,9 +32,7 @@ Current rate limits are as follows:
 | /curations    | POST    | 250 /min |
 | /notices      | POST    | 250 /min |
 
-All other endpoints are max 2K requests per minute. 
-
-You can check the _x-ratelimit-limit_ and _x-ratelimit-remaining_ response headers to track your usage.
+All other endpoints are max 500 requests per every 5 minutes.
 
 ## ClearlyDefined Coordinates
 

--- a/docs/using-data.md
+++ b/docs/using-data.md
@@ -15,9 +15,9 @@ Host: [api.clearlydefined.io](https://api.clearlydefined.io/)
 
 | Endpoint      | Method  | Limit    |
 |---------------|---------|----------|
-| /definitions  | POST    | 60 /min  |
-| /curations    | POST    | 60 /min  |
-| /notices      | POST    | 60 /min  |
+| /definitions  | POST    | 250 /min |
+| /curations    | POST    | 250 /min |
+| /notices      | POST    | 250 /min |
 
 All other endpoints are max 2K requests per minute. 
 

--- a/docs/using-data.md
+++ b/docs/using-data.md
@@ -15,11 +15,11 @@ If the rate limit is reached, an _HTTP 429_ response code will be returned. The 
 Host: [api.clearlydefined.io](https://api.clearlydefined.io/)
 \([Docs](https://api.clearlydefined.io/api-docs/)\)
 
-| Endpoint      | Method  | Limit    | Window |
-|---------------|---------|----------|--------|
-| /definitions  | POST    | 250 /min | 1 min  |
-| /curations    | POST    | 250 /min | 1 min  |
-| /notices      | POST    | 250 /min | 1 min  |
+| Endpoint      | Method  | Limit/Window    |
+|---------------|---------|-----------------|
+| /definitions  | POST    | 250 /min        |
+| /curations    | POST    | 250 /min        |
+| /notices      | POST    | 250 /min        |
 
 All other endpoints are max 2K requests per minute. 
 
@@ -28,11 +28,11 @@ All other endpoints are max 2K requests per minute.
 Host: [dev-api.clearlydefined.io](https://dev-api.clearlydefined.io/)
 \([Docs](https://dev-api.clearlydefined.io/api-docs/)\)
 
-| Endpoint      | Method  | Limit    | Window |
-|---------------|---------|----------|--------|
-| /definitions  | POST    | 250 /min | 5 min  |
-| /curations    | POST    | 250 /min | 5 min  |
-| /notices      | POST    | 250 /min | 5 min  |
+| Endpoint      | Method  | Limit/Window    |
+|---------------|---------|-----------------|
+| /definitions  | POST    | 250 /min        |
+| /curations    | POST    | 250 /min        |
+| /notices      | POST    | 250 /min        |
 
 All other endpoints are max 500 requests per every 5 minutes.
 

--- a/docs/using-data.md
+++ b/docs/using-data.md
@@ -2,6 +2,22 @@
 
 All of the ClearlyDefined data is available for everyone to see and use. You can browse and inspect in a [convenient web ui](#website) or hook up a client to the [REST API](https://api.clearlydefined.io/api-docs/) and integrate it into your systems.
 
+## API Usage Considerations
+
+Current rate limits are as follows:
+
+### Endpoint-Specific Restrictions
+
+| Endpoint      | Method  | Limit    |
+|---------------|---------|----------|
+| /definitions  | POST    | 250 /min |
+| /curations    | POST    | 250 /min |
+| /notices      | POST    | 250 /min |
+
+All other endpoints are max 2K requests per minute. 
+
+You can check the _x-ratelimit-limit_ and _x-ratelimit-remaining_ response headers to track your usage.
+
 ## ClearlyDefined Coordinates
 
 In order to use ClearlyDefined's data (whether through the REST API or the Web UI), it's critical to understand how to find a component in the data. ClearlyDefined uses a system of **coordinates** to navigate to data about particular components.


### PR DESCRIPTION
Add the current API rate limits under a new general _API Usage Considerations_ section.

This is intended to address issue #160.

@mpcen and @qtomlinson : AFAIK these are the current applicable rate limits. Please do correct me if I'm wrong.