### PR TITLE
turn build docs action back on and send a minor change to Glossary to force a rebuild

### DIFF
--- a/.github/workflows/build-documentation.yaml
+++ b/.github/workflows/build-documentation.yaml
@@ -2,9 +2,9 @@ name: Build Documentation
 
 on:
   workflow_dispatch:
-  # push:
-  #   branches:
-  #     - main
+  push:
+    branches:
+      - main
 
 jobs:
   build:

--- a/docs/resources/glossary.md
+++ b/docs/resources/glossary.md
@@ -6,7 +6,7 @@ title: Glossary
 
 # Glossary
 
-There are relatively few concepts and verbs in ClearlyDefined. Here is
+There are a few concepts and verbs in ClearlyDefined. Here is
 a summary of the terms and their meanings:
 
 ### Adopter


### PR DESCRIPTION
The build docs action was deactived to allow deletion of the .docusaurus directory and contents before adding of .docusaurus to the .gitignore file.

* PR https://github.com/clearlydefined/clearlydefined/pull/179
* PR https://github.com/clearlydefined/clearlydefined/pull/178

The change to the Glossary forces a rebuild of the documentation.