### PR TITLE
docs: fix typos from pr #166

### DIFF
--- a/docs/curation/curation-guidelines.md
+++ b/docs/curation/curation-guidelines.md
@@ -33,7 +33,7 @@ Both may contain equally valuable information and should be reviewed and curated
 
 The ClearlyDefined definition for a component has two types of license information: declared and discovered.
 
-- The _declared license_ for a component is what the component explicitly calls out, formally or through convention, as the overall license. This might be a `LICENSE` or `README` file at the root of a repo or the value of a `LICENSE` property in a package’s metadata such as packgage.json or pom.xml.
+- The _declared license_ for a component is what the component explicitly calls out, formally or through convention, as the overall license. This might be a `LICENSE` or `README` file at the root of a repo or the value of a `LICENSE` property in a package’s metadata such as package.json or pom.xml.
 - The _discovered licenses_ in a component’s definition are the other licenses found in the files of the component or sub-components of the overall project. For example, a source file or sub-directory might have a header comment indicating an SPDX license id, or a sub-directory might be under a different license.
 
 In other words, the declared license is what normal developers would understand the component producers intended the overall project license to be. The discovered licenses represent what other licenses are found in the component.

--- a/docs/get-involved/contributing-code.md
+++ b/docs/get-involved/contributing-code.md
@@ -66,13 +66,13 @@ Always a topic in code and ClearlyDefined is no different. Here we follow these 
   letter variable names should be avoided except in certain very well known cases like loop indexes (e.g., `i`).
 - _Private -- Functions that are private to a class should be prefixed with an `_` (underscore). Note that this
   convention is not well-practiced at the moment.
-- Negative names -- Avoid negative names like `disbleCache`. Err, `disbleCache = true` means the cache is enabled?
+- Negative names -- Avoid negative names like `disableCache`. Err, `disableCache = true` means the cache is enabled?
   Now try `if (!disableCache) ...`. Instead, use `enableCache` defaulted to false (if that's what you want).
 
 ## Formatting
 
 As a general rule all code should be formatted using `prettier` and the settings in the `.prettierrc` file in
-the repo. Pleaes don't override them with local settings somehow. Here is a brief summary of the main points:
+the repo. Please don't override them with local settings somehow. Here is a brief summary of the main points:
 
 - Spaces not tabs. 'nuff said.
 - Minimal vertical white space. If you find you need to add blank lines to separate parts of a function,

--- a/docs/get-involved/contributing-data.md
+++ b/docs/get-involved/contributing-data.md
@@ -31,11 +31,11 @@ Either way you should pick the one that best matches your
 interests. For example, if you are using `jquery` there's a good chance that there is an npm, maven
 package and several forms. Pick the one from the source that most closely matches your interests.
 
-Having selected the one that you want, update the definiiton in the bottom right editor to match
+Having selected the one that you want, update the definition in the bottom right editor to match
 you new info. For example, if you found the source location, create a `sourceLocation` property
 in the `described` section and fill in the data.
 
-Once you have finished you data entry, click **Contribute curation**. That askes you for
+Once you have finished you data entry, click **Contribute curation**. That asks you for
 some descriptive info on your suggestions and then opens a pull request in
 [curation repo on GitHub](https://github.com/clearlydefined/curated-data). Curators will take a
 look at your suggestion, validate your approach and then merge the changes into the curation repo.

--- a/docs/get-involved/get-involved.md
+++ b/docs/get-involved/get-involved.md
@@ -40,7 +40,7 @@ Check out the [mock job posting for project adopters](/docs/roles/adopter).
 
 If you are like hundreds of others, you may spend a bunch of time figuring out the
 exact source code commit for a component version, or the license or attribution details for
-a compoenent. Wouldn't it be great if you could share that with folks or find information
+a component. Wouldn't it be great if you could share that with folks or find information
 that others have discovered? Head over to the [data contribution guide](/docs/get-involved/contributing-data)
 to learn more about enhancing the data in ClearlyDefined. Check out the [mock job posting
 for data contributors](/docs/roles/data-contributor).

--- a/docs/get-involved/using-data.md
+++ b/docs/get-involved/using-data.md
@@ -286,7 +286,7 @@ This is what we call, _the identity problem_. ClearlyDefined is NOT attempting t
 
 ## Curation
 
-New curations, or changes to existing curations, are done via PATCHes. Ultimately these surface as PRs in the configured curation repo. They can be manipulated directy there but using this API keeps things regular. A set of curations is described together with its general intent, and understood as a `contribution`. Below is an example contribution.
+New curations, or changes to existing curations, are done via PATCHes. Ultimately these surface as PRs in the configured curation repo. They can be manipulated directly there but using this API keeps things regular. A set of curations is described together with its general intent, and understood as a `contribution`. Below is an example contribution.
 
 ```json
 {

--- a/docs/resources/architecture.md
+++ b/docs/resources/architecture.md
@@ -6,7 +6,7 @@ title: Architecture
 
 # Architecture
 
-ClearlyDefined is structured as a set of stateles, micro-services that can scale horizontally with ease.
+ClearlyDefined is structured as a set of stateless, micro-services that can scale horizontally with ease.
 The services collaborate via REST APIs using shared service-to-service tokens and/or shared access to storage
 (e.g., blob storage). The website is React-based an talks almost solely to the service.
 
@@ -32,7 +32,7 @@ Unsurprisingly, the `service` is at the heart of the system. It supports a [set 
 - Harvesting -- Get or queue traversals of components of various supported types
 - Origin scanning -- Support for searching and selecting components and versions from a wide range of systems such as GitHub, npmjs, Maven Central.
 
-The service process itself is completely stateless and can scale horizontally as needed. It does relativley little compute itself. The heaviest lifting it does is summarizing, aggregating and curating definitions from their
+The service process itself is completely stateless and can scale horizontally as needed. It does relatively little compute itself. The heaviest lifting it does is summarizing, aggregating and curating definitions from their
 constituent parts. That computation is only done once and then cached until invalidated by new data. So, most of
 the time the service is listing blobs or getting blobs and returning their content.
 
@@ -44,7 +44,7 @@ logic is probably < 500 lines of Node code.
 
 The website is a simple React app that uses the [Create React App framework](https://github.com/facebook/create-react-app), [Redux](https://redux.js.org) and [React-Bootstrap](https://react-bootstrap.github.io). All of its content comes via the service, even when it is talking to GitHub or npmjs or Maven Central. This allows us to manage access tokens, do caching, and precompute results. This approach also simplifies client code and enables the easy creation of alternative front-ends with consistent functional behavior.
 
-The app was put together by new React devs so is bound to have a number of less than opitimal designs and approaches.
+The app was put together by new React devs so is bound to have a number of less than optimal designs and approaches.
 
 ### Badges
 
@@ -55,7 +55,7 @@ So, for example:
 /badges/git/github/expressjs/express/351396f971280ab79faddcf9782ea50f4e88358d
 
 You can embed this into your open source project by putting the following markdown into your Readme.
-(Note please replace variables with your poject information)
+(Note please replace variables with your project information)
 
 ```
 ![My ClearlyDefined Score](https://api.clearlydefined.io/badges/:type/:provider/:namespace/:name/:revision)

--- a/docs/resources/defined.md
+++ b/docs/resources/defined.md
@@ -12,7 +12,7 @@ ClearlyDefined seeks to identify the minimal possible set of factual information
 
 ## Described
 
-For communities to engage with confidence, they need to know what they are getting into. For example, when using a version of a component, knowing the location of the source, where the project lives and where issues are managed help users understand the project more clearly and more quickly. Note that this is not intended to be a catch all bag of subjective information. Rather, we gather essential factal information about component itself.
+For communities to engage with confidence, they need to know what they are getting into. For example, when using a version of a component, knowing the location of the source, where the project lives and where issues are managed help users understand the project more clearly and more quickly. Note that this is not intended to be a catch all bag of subjective information. Rather, we gather essential factual information about component itself.
 
 The full set of properties that make a component ClearlyDescribed:
 
@@ -22,15 +22,15 @@ The full set of properties that make a component ClearlyDescribed:
   - url
   - revision
   - path
-- issueTracker - The URL to the system in which bugs and features are tracked for the described component. Knowing the issues tracker allows the community to engage more fully in the evolution of the component. This locaton may change after the component was released and the definition published. As such, the value of this property may be updated at any time.
-- projectWebsite - The URL to the website where the community for the described component lives. Knowing the website enables users to find documentation, better understand the component, and to find and collaborate with the community. This locaton may change after the component was released and the definition published. As such, the value of this property may be updated at any time.
+- issueTracker - The URL to the system in which bugs and features are tracked for the described component. Knowing the issues tracker allows the community to engage more fully in the evolution of the component. This location may change after the component was released and the definition published. As such, the value of this property may be updated at any time.
+- projectWebsite - The URL to the website where the community for the described component lives. Knowing the website enables users to find documentation, better understand the component, and to find and collaborate with the community. This location may change after the component was released and the definition published. As such, the value of this property may be updated at any time.
 - releaseDate -- The ISO8601 date when the component was released. While more precision may be included, generally you should assume the release date to the day. Unless there are corrections, this value should not change.
 
 ### Facets
 
 It turns out that many projects contain an assortment of code, only some of which is actually part of the component they ship. For example, tests and samples generally are not part of the release of a project. As such, consumers generally need not be concerned with the licenses of that content. For example, the packaged [TypeScript](https://github.com/microsoft/typescript) component includes about 200 files but the full source of the component has >36,000 files -- lots of tests.
 
-To accomodate this level of detail and variation, ClearlyDefined's _described_ domain includes the notion of _facets_. A facet of a component is a subset of the files related to the component. It's really just a grouping that helps us understand the shape of the project. Each facet is described by a set of `glob` expressions -- essentially wildcart patterns that are matched against filenames.
+To accommodate this level of detail and variation, ClearlyDefined's _described_ domain includes the notion of _facets_. A facet of a component is a subset of the files related to the component. It's really just a grouping that helps us understand the shape of the project. Each facet is described by a set of `glob` expressions -- essentially wildcard patterns that are matched against filenames.
 
 While there are many different ways to slice up one's source, for simplicity and generality, ClearlyDefined identifies a fixed set of canonical facets as discussed below. The facet declarations are not meant to be hard and fast rules nor are they intended for anything other than the uses in ClearlyDefined -- differentiating files that go in the delivery/consumption forms of the component. In short, think of this as specifying what goes into the consumed outputs. You need not fill in each facet. Key element is that all files that go into the release are part of the relevant facet.
 
@@ -45,7 +45,7 @@ Each facet definition can have zero or more glob expressions. A file can be capt
 
 ## Licensed
 
-Being ClearlyLicensed is a main focus of ClearlyDefined. Many projects have a license. Not all are clearly identified or identified uniformely. Often times there are more licenses at play in the code than are stated in the project. Even when the license is known, the information required to comply with the license (e.g., source location and the parties to the attribution requirement) are not always clear.
+Being ClearlyLicensed is a main focus of ClearlyDefined. Many projects have a license. Not all are clearly identified or identified uniformly. Often times there are more licenses at play in the code than are stated in the project. Even when the license is known, the information required to comply with the license (e.g., source location and the parties to the attribution requirement) are not always clear.
 
 This ambiguity results in component users who either end up not following the project requirements or who spend enormous effort trying to "get it right". ClearlyDefined addresses both scenarios by clarifying the licensing information around a component.
 
@@ -66,4 +66,4 @@ Each facet includes the following licensing-related information:
 
 Component security is an important and evolving area. ClearlyDefined is helping project teams be explicit about their security approach and any vulnerabilities they may have found and fixed. This is meant to augment existing efforts such as the NIST database and security.org.
 
-As the initial focus of ClearlyDefined is on licening related information, the notion of being ClearlySecured is still being fleshed out. You can help shape the secure domain by defining scenarios to be supported (or not).
+As the initial focus of ClearlyDefined is on licensing related information, the notion of being ClearlySecured is still being fleshed out. You can help shape the secure domain by defining scenarios to be supported (or not).

--- a/docs/resources/glossary.md
+++ b/docs/resources/glossary.md
@@ -110,7 +110,7 @@ otherwise access the definitions for their components of interest.
 
 Harvesting is the act of running one or more tools on a revision of a
 component. The resultant tool outputs are stored for future use in
-summarization and the creation of defintions.
+summarization and the creation of definitions.
 
 ### Summary
 


### PR DESCRIPTION
Fixing typos from PR #166, but now for the new documentation website.