### PR TITLE
fix(docs): link to contributing data from docs homepage

### DIFF
--- a/src/components/HomepageFeatures/index.js
+++ b/src/components/HomepageFeatures/index.js
@@ -26,7 +26,7 @@ const FeatureList = [
   {
     title: 'Contribute data',
     image: require('@site/static/img/contribute_data.png').default,
-    link: '/docs/get-involved/contribute-data',
+    link: '/docs/get-involved/contributing-data',
     description: (
       <>
         Enhacing the data is something that anyone can do.


### PR DESCRIPTION
https://docs.clearlydefined.io/ Currently the `Contribute Data` link 404s

![Screenshot 2024-06-06 at 10 06 17 AM](https://github.com/clearlydefined/clearlydefined/assets/35014/08b67ade-ed04-45b9-adbd-408e4c585ac8)


