### PR TITLE
docs: add blog beyond spdx

### DIFF
--- a/blog/2024-07-09-beyond-spdx.md
+++ b/blog/2024-07-09-beyond-spdx.md
@@ -1,0 +1,10 @@
+---
+slug: beyond-spdx
+title: Beyond SPDX, expanding licenses identified by ClearlyDefined
+authors: nickvidal
+tags: [spdx]
+---
+
+ClearlyDefined now supports non-SPDX licenses. Scancode already provides this functionality and it offers mapping from these non-SPDX licenses to the SPDX LicenseRef. Organizations using ClearlyDefined now have the option to decide how to handle non-SPDX licenses based on their own needs.
+
+Read more: https://opensource.org/blog/beyond-spdx-expanding-licenses-identified-by-clearlydefined


### PR DESCRIPTION
add blog [Beyond SPDX: expanding licenses identified by ClearlyDefined](https://opensource.org/blog/beyond-spdx-expanding-licenses-identified-by-clearlydefined)