### PR TITLE
Updating docs edit url and fixing 'Contribute code' link on homepage

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -83,7 +83,7 @@ const config = {
           // Please change this to your repo.
           // Remove this to remove the "edit this page" links.
           editUrl:
-            'https://github.com/clearlydefined/clearlydefined',
+            'https://github.com/clearlydefined/clearlydefined/tree/main/',
         },
         blog: {
           showReadingTime: true,

--- a/src/components/HomepageFeatures/index.js
+++ b/src/components/HomepageFeatures/index.js
@@ -36,7 +36,7 @@ const FeatureList = [
   {
     title: 'Contribute code',
     image: require('@site/static/img/contribute_code.png').default,
-    link: '/docs/get-involved/contribute-code',
+    link: '/docs/get-involved/contributing-code',
     description: (
       <>
         It’s about the data but there is a non-trivial service that drives it.


### PR DESCRIPTION
This fixes https://github.com/clearlydefined/website/issues/1049 and updates the link to contributing code page.