### PR TITLE
docs: fix contributing-code url

### DIFF
--- a/src/components/HomepageFeatures/index.js
+++ b/src/components/HomepageFeatures/index.js
@@ -36,7 +36,7 @@ const FeatureList = [
   {
     title: 'Contribute code',
     image: require('@site/static/img/contribute_code.png').default,
-    link: '/docs/get-involved/contribute-code',
+    link: '/docs/get-involved/contributing-code',
     description: (
       <>
         It’s about the data but there is a non-trivial service that drives it.


### PR DESCRIPTION
Fix broken url:

- from: https://docs.clearlydefined.io/docs/get-involved/contribute-code
- to: https://docs.clearlydefined.io/docs/get-involved/contributing-code